### PR TITLE
Update sccache version to 0.9.1

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -83,7 +83,7 @@ ENV RUSTUP_HOME="/opt/rust" \
 
 RUN rustup default stable && \
     rustup component remove rust-docs && \
-    cargo install --root /usr/local --version 0.8.1 --locked sccache && \
+    cargo install --root /usr/local --version 0.9.1 --locked sccache && \
     cargo install --root /usr/local cargo-c
 
 # Copy jhbuild helper files and do the initial build & install


### PR DESCRIPTION
Didn't try this but it should work, given cargo supports version 0.9.1.
The latter is confirmed by `cargo info sccache`.

This potentially fixes incremental build bugs for WebKit, see
<https://bugs.webkit.org/show_bug.cgi?id=286676>.
